### PR TITLE
add the missing passed var

### DIFF
--- a/emr_launcher/handler.py
+++ b/emr_launcher/handler.py
@@ -115,7 +115,9 @@ def old_handler(event=None) -> dict:
         correlation_id_necessary = True
 
     cluster_config = read_config("cluster")
-    cluster_config.update(read_config("configurations", False))
+    cluster_config.update(
+        read_config(config_type="configurations", s3_overrides=None, required=False)
+    )
 
     try:
         if (


### PR DESCRIPTION
old handler was missing a parameter: s3_overrides which needs to be set to None in the old_handler. 